### PR TITLE
Bumping release to v0.17.7

### DIFF
--- a/io.github.daviddesimone.opencloudsaves.yml
+++ b/io.github.daviddesimone.opencloudsaves.yml
@@ -30,8 +30,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/DavidDeSimone/OpenCloudSaves
-        tag: v0.17.6
-        commit: bba72ef39ff7fbef1ea2c9980a6322347f230930
+        tag: v0.17.7
+        commit: 6ab98739056829d788309eb691b37da1dea462e8
   - name: rclone
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This release fixes a critical bug in setting up NextCloud usage for cloud saves. Now the user will be prompt'd with a way to enter NextCloud login information. 